### PR TITLE
Fix PROACTIVE_EVENT_DEV_URI

### DIFF
--- a/src/main/java/com/xavidop/alexa/utilities/Constants.java
+++ b/src/main/java/com/xavidop/alexa/utilities/Constants.java
@@ -6,5 +6,5 @@ public final class Constants {
     public static final String PROACTIVE_EVENT_EU_URL = "https://api.eu.amazonalexa.com/v1/proactiveEvents/";
     public static final String PROACTIVE_EVENT_NA_URL = "https://api.amazonalexa.com/v1/proactiveEvents/";
     public static final String PROACTIVE_EVENT_FE_URL = "https://api.fe.amazonalexa.com/v1/proactiveEvents/";
-    public static final String PROACTIVE_EVENT_DEV_URI= "/stages/development";
+    public static final String PROACTIVE_EVENT_DEV_URI= "stages/development";
 }


### PR DESCRIPTION
Without this fix, the constructed development URL contains a double slash ("//"), which leads to AWS to reject the request with a 500.